### PR TITLE
Add word-wrap to the body element

### DIFF
--- a/.dev/sass/mixins/_global.scss
+++ b/.dev/sass/mixins/_global.scss
@@ -310,6 +310,7 @@ body {
 	line-height: $base-line-height; // Set to $base-line-height to take on browser default of 150%
 	cursor: $cursor-default-value;
 	-webkit-font-smoothing: antialiased;
+	word-wrap: break-word;
 }
 
 a:hover { cursor: $cursor-pointer-value; }

--- a/editor-style-rtl.css
+++ b/editor-style-rtl.css
@@ -43,7 +43,8 @@ body {
   font-style: normal;
   line-height: 150%;
   cursor: default;
-  -webkit-font-smoothing: antialiased; }
+  -webkit-font-smoothing: antialiased;
+  word-wrap: break-word; }
 
 a:hover {
   cursor: pointer; }
@@ -1289,7 +1290,8 @@ body {
   font-style: normal;
   line-height: 150%;
   cursor: default;
-  -webkit-font-smoothing: antialiased; }
+  -webkit-font-smoothing: antialiased;
+  word-wrap: break-word; }
 
 a:hover {
   cursor: pointer; }
@@ -1404,7 +1406,8 @@ body {
   font-style: normal;
   line-height: 150%;
   cursor: default;
-  -webkit-font-smoothing: antialiased; }
+  -webkit-font-smoothing: antialiased;
+  word-wrap: break-word; }
 
 a:hover {
   cursor: pointer; }

--- a/editor-style.css
+++ b/editor-style.css
@@ -43,7 +43,8 @@ body {
   font-style: normal;
   line-height: 150%;
   cursor: default;
-  -webkit-font-smoothing: antialiased; }
+  -webkit-font-smoothing: antialiased;
+  word-wrap: break-word; }
 
 a:hover {
   cursor: pointer; }
@@ -1289,7 +1290,8 @@ body {
   font-style: normal;
   line-height: 150%;
   cursor: default;
-  -webkit-font-smoothing: antialiased; }
+  -webkit-font-smoothing: antialiased;
+  word-wrap: break-word; }
 
 a:hover {
   cursor: pointer; }
@@ -1404,7 +1406,8 @@ body {
   font-style: normal;
   line-height: 150%;
   cursor: default;
-  -webkit-font-smoothing: antialiased; }
+  -webkit-font-smoothing: antialiased;
+  word-wrap: break-word; }
 
 a:hover {
   cursor: pointer; }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -62,7 +62,8 @@ body {
   font-style: normal;
   line-height: 150%;
   cursor: default;
-  -webkit-font-smoothing: antialiased; }
+  -webkit-font-smoothing: antialiased;
+  word-wrap: break-word; }
 
 a:hover {
   cursor: pointer; }
@@ -177,7 +178,8 @@ body {
   font-style: normal;
   line-height: 150%;
   cursor: default;
-  -webkit-font-smoothing: antialiased; }
+  -webkit-font-smoothing: antialiased;
+  word-wrap: break-word; }
 
 a:hover {
   cursor: pointer; }
@@ -2133,7 +2135,8 @@ body {
   font-style: normal;
   line-height: 150%;
   cursor: default;
-  -webkit-font-smoothing: antialiased; }
+  -webkit-font-smoothing: antialiased;
+  word-wrap: break-word; }
 
 a:hover {
   cursor: pointer; }

--- a/style.css
+++ b/style.css
@@ -62,7 +62,8 @@ body {
   font-style: normal;
   line-height: 150%;
   cursor: default;
-  -webkit-font-smoothing: antialiased; }
+  -webkit-font-smoothing: antialiased;
+  word-wrap: break-word; }
 
 a:hover {
   cursor: pointer; }
@@ -177,7 +178,8 @@ body {
   font-style: normal;
   line-height: 150%;
   cursor: default;
-  -webkit-font-smoothing: antialiased; }
+  -webkit-font-smoothing: antialiased;
+  word-wrap: break-word; }
 
 a:hover {
   cursor: pointer; }
@@ -2133,7 +2135,8 @@ body {
   font-style: normal;
   line-height: 150%;
   cursor: default;
-  -webkit-font-smoothing: antialiased; }
+  -webkit-font-smoothing: antialiased;
+  word-wrap: break-word; }
 
 a:hover {
   cursor: pointer; }


### PR DESCRIPTION
Helps prevent long words from overflowing outside of the content area (especially on smaller devices)