### PR TITLE
Adjust styles, prevent long site title .hero overlap

### DIFF
--- a/.dev/sass/partials/_header.scss
+++ b/.dev/sass/partials/_header.scss
@@ -138,5 +138,8 @@ $entry-title-bg: rgba(0, 0, 0, 0.6) !default;
 	.site-header {
 		padding: 120px 0 60px;
 		position: relative;
+		@media #{$small-only} {
+			padding-top: 0;
+		}
 	}
 }

--- a/.dev/sass/partials/_menus.scss
+++ b/.dev/sass/partials/_menus.scss
@@ -271,11 +271,21 @@ body {
 
 /* Small menu */
 .menu-toggle {
-	width: 70px;
-	padding: 15px 15px 10px 10px;
+	//width: 70px;
+	//padding: 15px 15px 10px 10px;
+	//cursor: pointer;
+	//float: right;
+	//display: block;
+
+	width: 3.6rem;
+	padding: 0.3rem;
 	cursor: pointer;
-	float: right;
+	display: none;
+	position: absolute;
+	top: 4px;
+	right: 0;
 	display: block;
+	z-index: 99999;
 
 	@media #{$medium-up}{
 		display: none;
@@ -283,9 +293,28 @@ body {
 
 	div {
 		background: #fff;
-		height: 4px;
-		margin: 6px;
-		border-radius: 1px;
+		margin: 0.43rem .86rem 0.43rem 0;
+		transform: rotate(0deg);
+		transition: .15s ease-in-out;
+		transform-origin: left center;
+		height: 0.32rem;
+	}
+
+	&.open {
+		div {
+			&:nth-child(1) {
+				transform: rotate(45deg);
+			}
+
+			&:nth-child(2) {
+				width: 0%;
+				opacity: 0;
+			}
+
+			&:nth-child(3) {
+				transform: rotate(-45deg);
+			}
+		}
 	}
 }
 
@@ -316,6 +345,12 @@ body {
 
 	.site-logo {
 		display: none;
+	}
+
+	.site-title-wrapper {
+		@media #{$small-only}{
+			width: 80%;
+		}
 	}
 
 	.site-title {

--- a/.dev/sass/partials/_menus.scss
+++ b/.dev/sass/partials/_menus.scss
@@ -291,13 +291,14 @@ body {
 
 .side-masthead {
 	@include clearfix;
-	position: absolute;
+	position: relative;
 	width: 100%;
 	top: 0;
 	text-align: center;
 	z-index: 9999;
 	background-color: $menu-bg-ie;
 	background-color: $menu-background-color;
+	margin-bottom: 60px;
 
 	@media #{$medium-up}{
 		position: fixed;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2995,20 +2995,41 @@ a {
 
 /* Small menu */
 .menu-toggle {
-  width: 70px;
-  padding: 15px 10px 10px 15px;
+  width: 3.6rem;
+  padding: 0.3rem;
   cursor: pointer;
-  float: left;
-  display: block; }
+  display: none;
+  position: absolute;
+  top: 4px;
+  left: 0;
+  display: block;
+  z-index: 99999; }
   @media only screen and (min-width: 55.063em) {
     .menu-toggle {
       display: none; } }
   .menu-toggle div {
     background: #fff;
-    height: 4px;
-    margin: 6px;
-    -webkit-border-radius: 1px;
-    border-radius: 1px; }
+    margin: 0.43rem 0 0.43rem .86rem;
+    -webkit-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+    -webkit-transition: .15s ease-in-out;
+    transition: .15s ease-in-out;
+    -webkit-transform-origin: right center;
+    -ms-transform-origin: right center;
+    transform-origin: right center;
+    height: 0.32rem; }
+  .menu-toggle.open div:nth-child(1) {
+    -webkit-transform: rotate(45deg);
+    -ms-transform: rotate(45deg);
+    transform: rotate(45deg); }
+  .menu-toggle.open div:nth-child(2) {
+    width: 0%;
+    opacity: 0; }
+  .menu-toggle.open div:nth-child(3) {
+    -webkit-transform: rotate(-45deg);
+    -ms-transform: rotate(-45deg);
+    transform: rotate(-45deg); }
 
 .side-masthead {
   position: relative;
@@ -3035,6 +3056,9 @@ a {
     clear: both; }
   .side-masthead .site-logo {
     display: none; }
+  @media only screen and (max-width: 55em) {
+    .side-masthead .site-title-wrapper {
+      width: 80%; } }
   .side-masthead .site-title {
     line-height: 53px;
     font-size: 30px;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3011,13 +3011,14 @@ a {
     border-radius: 1px; }
 
 .side-masthead {
-  position: absolute;
+  position: relative;
   width: 100%;
   top: 0;
   text-align: center;
   z-index: 9999;
   background-color: #191919;
-  background-color: rgba(25, 25, 25, 0.95); }
+  background-color: rgba(25, 25, 25, 0.95);
+  margin-bottom: 60px; }
   .side-masthead:before, .side-masthead:after {
     content: " ";
     display: table; }
@@ -3966,6 +3967,12 @@ body.layout-one-column-narrow #content {
 .single .site-header {
   padding: 120px 0 60px;
   position: relative; }
+  @media only screen and (max-width: 55em) {
+    .blog .site-header,
+    .page .site-header,
+    .archive .site-header,
+    .single .site-header {
+      padding-top: 0; } }
 
 .site-footer {
   background-color: #414242;

--- a/style.css
+++ b/style.css
@@ -3011,13 +3011,14 @@ a {
     border-radius: 1px; }
 
 .side-masthead {
-  position: absolute;
+  position: relative;
   width: 100%;
   top: 0;
   text-align: center;
   z-index: 9999;
   background-color: #191919;
-  background-color: rgba(25, 25, 25, 0.95); }
+  background-color: rgba(25, 25, 25, 0.95);
+  margin-bottom: 60px; }
   .side-masthead:before, .side-masthead:after {
     content: " ";
     display: table; }
@@ -3966,6 +3967,12 @@ body.layout-one-column-narrow #content {
 .single .site-header {
   padding: 120px 0 60px;
   position: relative; }
+  @media only screen and (max-width: 55em) {
+    .blog .site-header,
+    .page .site-header,
+    .archive .site-header,
+    .single .site-header {
+      padding-top: 0; } }
 
 .site-footer {
   background-color: #414242;

--- a/style.css
+++ b/style.css
@@ -2995,20 +2995,41 @@ a {
 
 /* Small menu */
 .menu-toggle {
-  width: 70px;
-  padding: 15px 15px 10px 10px;
+  width: 3.6rem;
+  padding: 0.3rem;
   cursor: pointer;
-  float: right;
-  display: block; }
+  display: none;
+  position: absolute;
+  top: 4px;
+  right: 0;
+  display: block;
+  z-index: 99999; }
   @media only screen and (min-width: 55.063em) {
     .menu-toggle {
       display: none; } }
   .menu-toggle div {
     background: #fff;
-    height: 4px;
-    margin: 6px;
-    -webkit-border-radius: 1px;
-    border-radius: 1px; }
+    margin: 0.43rem .86rem 0.43rem 0;
+    -webkit-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+    -webkit-transition: .15s ease-in-out;
+    transition: .15s ease-in-out;
+    -webkit-transform-origin: left center;
+    -ms-transform-origin: left center;
+    transform-origin: left center;
+    height: 0.32rem; }
+  .menu-toggle.open div:nth-child(1) {
+    -webkit-transform: rotate(45deg);
+    -ms-transform: rotate(45deg);
+    transform: rotate(45deg); }
+  .menu-toggle.open div:nth-child(2) {
+    width: 0%;
+    opacity: 0; }
+  .menu-toggle.open div:nth-child(3) {
+    -webkit-transform: rotate(-45deg);
+    -ms-transform: rotate(-45deg);
+    transform: rotate(-45deg); }
 
 .side-masthead {
   position: relative;
@@ -3035,6 +3056,9 @@ a {
     clear: both; }
   .side-masthead .site-logo {
     display: none; }
+  @media only screen and (max-width: 55em) {
+    .side-masthead .site-title-wrapper {
+      width: 80%; } }
   .side-masthead .site-title {
     line-height: 53px;
     font-size: 30px;


### PR DESCRIPTION
This patch adjust the theme styles so that long site titles don't cause an overlap on the elements below it, namely the `.hero` element on the homepage.