### PR TITLE
Remove bottom margin on the side masthead

### DIFF
--- a/.dev/sass/partials/_menus.scss
+++ b/.dev/sass/partials/_menus.scss
@@ -327,7 +327,6 @@ body {
 	z-index: 9999;
 	background-color: $menu-bg-ie;
 	background-color: $menu-background-color;
-	margin-bottom: 60px;
 
 	@media #{$medium-up}{
 		position: fixed;


### PR DESCRIPTION
I'm not sure if the side masthead, containing the menu and widgets, was designed to have a bottom margin - but when you scroll to the bottom of the page there is a white space.

This patch removes the bottom margin:

![Example before patch](https://cldup.com/tJ_utbDA6B.png)

![Example after patch](https://cldup.com/fnJEYMlLrW.png)