### PR TITLE
Update Primer hook priorities 

### DIFF
--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -121,10 +121,21 @@ li.menu-item-has-children.primer-wc-cart-menu:hover {
 
 }
 
+body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
+.woocommerce a.added_to_cart {
+	max-width: 100%;
+	white-space: normal;
+	text-align: center;
+	display: block;
+
+	@media #{$large-up} {
+		font-size: 0.75rem;
+	}
+
+}
+
 body.post-type-archive,
 body.single-product {
-
-	/* On Sale Badge */
 	span.onsale,
 	ul.products li.product .onsale {
 		padding: 2px 8px;

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -106,6 +106,93 @@
 
 }
 
+.woocommerce-page {
+
+	div.product {
+
+		.woocommerce-product-gallery {
+
+			figure.woocommerce-product-gallery__wrapper {
+				margin: 0;
+			}
+
+		}
+
+		.summary {
+			margin-top: 0;
+		}
+
+		.commentlist {
+			padding-left: 0;
+		}
+
+	}
+
+	&.woocommerce div.product form.cart {
+		margin: 1em 0;
+	}
+
+	ul.products li.product.primer-2-column-product {
+		width: 48.05%;
+	}
+
+	.primer-woocommerce .cart .qty {
+		padding: 0.42em;
+	}
+
+	table.variations tr:hover td {
+		background-color: transparent;
+	}
+
+	#reviews #comments ol.commentlist li {
+
+		img.avatar {
+			width: 60px;
+		}
+
+		.comment-text {
+			margin: 0 0 0 80px;
+		}
+
+	}
+
+	form.woocommerce-cart-form {
+
+		table.cart td.actions #coupon_code {
+			width: 55%;
+			margin-right: 0;
+
+		}
+
+	}
+
+	table.cart {
+
+		td.product-thumbnail,
+		td.product-remove {
+			text-align: center;
+
+			@media #{$large-only} {
+				.remove {
+					margin: 0 auto;
+				}
+			}
+		}
+
+		img {
+			width: 100%;
+			max-width: 75px;
+			margin-bottom: 0;
+		}
+
+		td.actions .input-text {
+			padding: 7px !important;
+		}
+
+	}
+
+}
+
 li.menu-item-has-children.primer-wc-cart-menu:hover {
 
 	ul.primer-wc-cart-sub-menu {
@@ -167,25 +254,6 @@ body.woocommerce-cart {
 	.primer-wc-cart-sub-menu {
 		display: none;
 	}
-}
-
-.woocommerce,
-.woocommerce-page {
-
-	table.cart {
-
-		img {
-			width: 100%;
-			max-width: 100px;
-			margin-bottom: 0;
-		}
-
-		td.actions .input-text {
-			padding: 7px !important;
-		}
-
-	}
-
 }
 
 .woocommerce ul.products li.product a.add_to_cart_button {

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -67,8 +67,8 @@
 		}
 
 		.total {
-			margin: 0 0 10px 0;
-			padding-top: 10px;
+			margin: 0;
+			padding: 10px 0;
 			text-align: center;
 
 			strong {
@@ -79,6 +79,7 @@
 
 		p.buttons {
 			padding: .5em;
+			padding-top: 0;
 			margin-bottom: 0;
 
 			a {
@@ -147,20 +148,23 @@ body.woocommerce-cart {
 	}
 }
 
-.woocommerce #content table.cart img,
-.woocommerce table.cart img,
-.woocommerce-page #content table.cart img,
-.woocommerce-page table.cart img {
-	width: 100%;
-	max-width: 100px;
-	margin-bottom: 0;
-}
+.woocommerce,
+.woocommerce-page {
 
-.woocommerce #content table.cart td.actions .input-text,
-.woocommerce table.cart td.actions .input-text,
-.woocommerce-page #content table.cart td.actions .input-text,
-.woocommerce-page table.cart td.actions .input-text {
-	padding: 7px;
+	table.cart {
+
+		img {
+			width: 100%;
+			max-width: 100px;
+			margin-bottom: 0;
+		}
+
+		td.actions .input-text {
+			padding: 7px !important;
+		}
+
+	}
+
 }
 
 .woocommerce ul.products li.product a.add_to_cart_button {

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -1,151 +1,117 @@
-.main-navigation .menu-item-object-cart:hover a {
-	background: transparent;
-}
+.primer-wc-cart-menu {
 
-ul.site-header-cart.menu {
-	width: 100%;
-	max-width: 275px;
-	padding: 0;
-	list-style: none;
-	float: right;
-	display: none;
-	position: relative;
-	z-index: 10001;
-}
-
-.site-footer-inner .woocommerce-cart-menu-item,
-.site-info-wrapper .woocommerce-cart-menu-item {
-	display: none;
-}
-
-.widget_shopping_cart {
-
-	float: left;
-	padding: 0 1rem;
-	margin-bottom: .5em;
-
-	.quantity {
-		font-style: italic;
-		color: #fff;
-	}
-
-	.total {
-		color: #fff;
-	}
-
-	ul.product_list_widget {
-		position: relative !important;
-		left: 0;
-		max-height: 250px;
-		overflow-y: auto;
-	}
-
-	p.buttons,
-	.total,
-	.product_list_widget {
-		float: left;
-		width: 100%;
-	}
-
-	.total strong {
-		text-index: 0;
-	}
-
-	p.buttons {
-		padding: .5em;
-		margin-bottom: 0;
-	}
-
-}
-
-.woocommerce-cart-menu-item .sub-menu {
-	background: transparent;
-}
-
-.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
-	padding: 0;
-	margin: 0;
-	width: 100%;
-	padding-bottom: 5px;
-	border-bottom: none;
-	padding: .5em 1em;
-	text-indent: 0;
-
-	a {
-		border-bottom: none;
-	}
-
-	a:nth-child(2) {
-		margin: 0;
-		width: 100%;
-		padding: .5em;
-		text-indent: 1px !important;
-	}
-}
-
-.woocommerce-cart-menu-item {
-
-	.product_list_widget {
-		border: none;
-		box-shadow: none;
-		display: inline-block;
-		left: 0 !important;
-		background: inherit;
+	.primer-wc-cart-sub-menu {
+		background: transparent;
 	}
 
 	.widget_shopping_cart {
 
+		float: left;
 		padding: 0;
+		background: #121212;
+
+		.cart_list li.mini_cart_item {
+			padding: 0;
+			margin: 0;
+			width: 100%;
+			padding-bottom: 5px;
+			border-bottom: none;
+			padding: .5em 1em;
+			text-indent: 0;
+
+			a {
+				border-bottom: none;
+				color: #757575;
+			}
+
+			&:hover a,
+			a:hover {
+				color: #fff;
+			}
+
+			a:nth-child(2) {
+				margin: 0;
+				width: 100%;
+				padding: .3em 0 .5em 1em;
+				text-indent: 1px;
+			}
+
+		}
+
+		.quantity {
+			font-style: italic;
+			color: #fff;
+			padding-left: 1.3em;
+		}
+
+		.total {
+			color: #fff;
+		}
+
+		ul.product_list_widget {
+			position: relative;
+			left: 0 !important;
+			max-height: 250px;
+			overflow-y: auto;
+			border: none;
+			box-shadow: none;
+			display: inline-block;
+			background: inherit;
+		}
+
+		p.buttons,
+		.total,
+		.product_list_widget {
+			float: left;
+			width: 100%;
+		}
 
 		.total {
 			margin: 0 0 10px 0;
 			padding-top: 10px;
 			text-align: center;
-		}
 
-		.total strong {
-			text-indent: 0;
-		}
-
-		p.buttons a {
-			text-align: center;
-			width: 100%;
-			text-indent: 0;
-
-			&:first-child {
-				margin-bottom: 5px;
+			strong {
+				text-index: 0;
 			}
 
 		}
 
-	}
+		p.buttons {
+			padding: .5em;
+			margin-bottom: 0;
 
-	.cart-preview-count {
-		margin-left: 8px;
+			a {
+				text-align: center;
+				width: 100%;
+				text-indent: 0;
+
+				&:first-child {
+					margin-bottom: 5px;
+				}
+
+			}
+		}
+
 	}
 
 	.cart_list li a.remove {
-		position: relative;
 		float: left;
 		padding: 0;
-		margin-top: 18px;
+		margin: 17px 5px 0 10px;
 		text-indent: 0;
-		margin-right: 5px;
 		z-index: 1001;
-		line-height: .8;
-		text-indent: 0 !important;
+		line-height: 1;
 
 		&:hover {
 			background: red !important;
 		}
 	}
 
-}
+	.cart-preview-count {
+		margin-left: 8px;
+	}
 
-li#woocommerce-cart-menu-item li.mini_cart_item a {
-	border-bottom: none;
-	text-indent: 15px;
-	margin-left: 10px;
 }
 
 body.post-type-archive,
@@ -174,30 +140,54 @@ body.single-product {
 
 }
 
-@media #{$medium-up} {
+body.woocommerce-cart {
 
-	li#woocommerce-cart-menu-item .sub-menu {
-		margin-left: -6em;
+	.primer-wc-cart-sub-menu {
+		display: none;
 	}
+}
 
+.woocommerce #content table.cart img,
+.woocommerce table.cart img,
+.woocommerce-page #content table.cart img,
+.woocommerce-page table.cart img {
+	width: 100%;
+	max-width: 100px;
+	margin-bottom: 0;
+}
+
+.woocommerce #content table.cart td.actions .input-text,
+.woocommerce table.cart td.actions .input-text,
+.woocommerce-page #content table.cart td.actions .input-text,
+.woocommerce-page table.cart td.actions .input-text {
+	padding: 7px;
+}
+
+.woocommerce ul.products li.product a.add_to_cart_button {
+	width: 100%;
+	font-size: 16px;
+	text-align: center;
 }
 
 @media #{$small-only} {
 
-	li#woocommerce-cart-menu-item {
+	.primer-wc-cart-menu-item {
 
 		.widget_shopping_cart {
 			width: 100%;
-		}
 
-		.widget_shopping_cart .quantity,
-		.widget_shopping_cart .total {
-			color: inherit;
-		}
+			.cart_list {
+				color: #fff;
 
-		.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) img {
-			width: 100%;
-			max-width: 65px;
+				a:nth-child(2) img {
+					width: 100%;
+					max-width: 65px;
+				}
+			}
+
+			.mini_cart_item a.remove {
+				margin-top: 20px;
+			}
 		}
 
 	}

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -8,7 +8,6 @@
 
 		float: left;
 		padding: 0;
-		background: #121212;
 
 		.cart_list li.mini_cart_item {
 			padding: 0;
@@ -19,20 +18,17 @@
 			padding: .5em 1em;
 			text-indent: 0;
 
-			a {
+			a,
+			.quantity,
+			a:hover {
 				border-bottom: none;
 				color: #757575;
-			}
-
-			&:hover a,
-			a:hover {
-				color: #fff;
 			}
 
 			a:nth-child(2) {
 				margin: 0;
 				width: 100%;
-				padding: .3em 0 .5em 1em;
+				padding: .3em 0 5px 1em;
 				text-indent: 1px;
 			}
 
@@ -40,12 +36,11 @@
 
 		.quantity {
 			font-style: italic;
-			color: #fff;
 			padding-left: 1.3em;
 		}
 
 		.total {
-			color: #fff;
+			color: #757575;
 		}
 
 		ul.product_list_widget {

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -134,6 +134,10 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
 
 }
 
+.woocommerce a.added_to_cart {
+	text-align: left;
+}
+
 body.post-type-archive,
 body.single-product {
 	span.onsale,

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -36,6 +36,8 @@ ul.site-header-cart.menu {
 	ul.product_list_widget {
 		position: relative !important;
 		left: 0;
+		max-height: 250px;
+		overflow-y: auto;
 	}
 
 	p.buttons,
@@ -144,6 +146,32 @@ li#woocommerce-cart-menu-item li.mini_cart_item a {
 	border-bottom: none;
 	text-indent: 15px;
 	margin-left: 10px;
+}
+
+body.post-type-archive,
+body.single-product {
+
+	/* On Sale Badge */
+	span.onsale,
+	ul.products li.product .onsale {
+		padding: 2px 8px;
+		border-radius: 0;
+		margin: 0;
+		min-height: auto;
+		min-width: auto;
+		line-height: inherit;
+	}
+
+}
+
+body.single-product {
+
+	span.onsale {
+		padding: 3px 18px;
+		top: 0;
+		left: 0;
+	}
+
 }
 
 @media #{$medium-up} {

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -1,0 +1,155 @@
+.main-navigation .menu-item-object-cart:hover a {
+	background: transparent;
+}
+
+ul.site-header-cart.menu {
+	width: 100%;
+	max-width: 275px;
+	padding: 0;
+	list-style: none;
+	float: right;
+	display: none;
+	position: relative;
+	z-index: 10001;
+}
+
+.site-footer-inner .woocommerce-cart-menu-item,
+.site-info-wrapper .woocommerce-cart-menu-item {
+	display: none;
+}
+
+.widget_shopping_cart {
+
+	float: left;
+	padding: 0 1rem;
+	margin-bottom: .5em;
+
+	.quantity {
+		font-style: italic;
+		color: #fff;
+	}
+
+	.total {
+		color: #fff;
+	}
+
+	ul.product_list_widget {
+		position: relative !important;
+		left: 0;
+	}
+
+	p.buttons,
+	.total,
+	.product_list_widget {
+		float: left;
+		width: 100%;
+	}
+
+	.total strong {
+		text-index: 0;
+	}
+
+	p.buttons {
+		padding: .5em;
+		margin-bottom: 0;
+	}
+
+}
+
+.woocommerce-cart-menu-item .sub-menu {
+	background: transparent;
+}
+
+.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
+	padding: 0;
+	margin: 0;
+	width: 100%;
+	padding-bottom: 5px;
+	border-bottom: none;
+	padding: .5em 1em;
+	text-indent: 0;
+
+	a {
+		border-bottom: none;
+	}
+
+	a:nth-child(2) {
+		padding: .5em 0em;
+		margin: 0;
+		width: 100%;
+		text-indent: 1.75rem;
+	}
+}
+
+.woocommerce-cart-menu-item {
+
+	.product_list_widget {
+		border: none;
+		box-shadow: none;
+		display: inline-block;
+		left: 0 !important;
+		background: inherit;
+	}
+
+	.widget_shopping_cart {
+
+		padding: 0;
+
+		.total {
+			margin: 0 0 10px 0;
+			padding-top: 10px;
+			text-align: center;
+		}
+
+		.total strong {
+			text-indent: 0;
+		}
+
+		p.buttons a {
+			text-align: center;
+			width: 100%;
+			text-indent: 0;
+
+			&:first-child {
+				margin-bottom: 5px;
+			}
+
+		}
+
+	}
+
+	.cart-preview-count {
+		margin-left: 8px;
+	}
+
+	.cart_list li a.remove {
+		position: relative;
+		float: left;
+		padding: 0;
+		margin-top: 18px;
+		text-indent: 0;
+		margin-right: 5px;
+		z-index: 1001;
+		line-height: .8;
+		text-indent: 0 !important;
+
+		&:hover {
+			background: red !important;
+		}
+	}
+
+}
+
+li#woocommerce-cart-menu-item li.mini_cart_item a {
+	border-bottom: none;
+	text-indent: 15px;
+	margin-left: 10px;
+}
+
+@media #{$medium-up} {
+
+	li#woocommerce-cart-menu-item .sub-menu {
+		margin-left: -6em;
+	}
+
+}

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -140,6 +140,16 @@
 		padding: 0.42em;
 	}
 
+	span.onsale,
+	ul.products li.product .onsale {
+		padding: 2px 8px;
+		border-radius: 0;
+		margin: 0;
+		min-height: auto;
+		min-width: auto;
+		line-height: inherit;
+	}
+
 	table.variations tr:hover td {
 		background-color: transparent;
 	}
@@ -223,20 +233,6 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
 
 .woocommerce a.added_to_cart {
 	text-align: left;
-}
-
-body.post-type-archive,
-body.single-product {
-	span.onsale,
-	ul.products li.product .onsale {
-		padding: 2px 8px;
-		border-radius: 0;
-		margin: 0;
-		min-height: auto;
-		min-width: auto;
-		line-height: inherit;
-	}
-
 }
 
 body.single-product {

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -1,9 +1,5 @@
 .primer-wc-cart-menu {
 
-	.primer-wc-cart-sub-menu {
-		background: transparent;
-	}
-
 	.widget_shopping_cart {
 
 		float: left;
@@ -106,6 +102,21 @@
 
 	.cart-preview-count {
 		margin-left: 8px;
+	}
+
+}
+
+li.menu-item-has-children.primer-wc-cart-menu:hover {
+
+	ul.primer-wc-cart-sub-menu {
+		background: $white;
+		-webkit-box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2);
+		box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2);
+
+		li:hover {
+			background: $white;
+		}
+
 	}
 
 }

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -28,6 +28,12 @@
 				text-indent: 1px;
 			}
 
+			dl.variation .variation-color {
+				margin-bottom: 0;
+				color: #757575;
+				line-height: 22px;
+			}
+
 		}
 
 		.quantity {

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -74,10 +74,10 @@ ul.site-header-cart.menu {
 	}
 
 	a:nth-child(2) {
-		padding: .5em 0em;
 		margin: 0;
 		width: 100%;
-		text-indent: 1.75rem;
+		padding: .5em;
+		text-indent: 1px !important;
 	}
 }
 
@@ -150,6 +150,28 @@ li#woocommerce-cart-menu-item li.mini_cart_item a {
 
 	li#woocommerce-cart-menu-item .sub-menu {
 		margin-left: -6em;
+	}
+
+}
+
+@media #{$small-only} {
+
+	li#woocommerce-cart-menu-item {
+
+		.widget_shopping_cart {
+			width: 100%;
+		}
+
+		.widget_shopping_cart .quantity,
+		.widget_shopping_cart .total {
+			color: inherit;
+		}
+
+		.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) img {
+			width: 100%;
+			max-width: 65px;
+		}
+
 	}
 
 }

--- a/.dev/sass/partials/_menus.scss
+++ b/.dev/sass/partials/_menus.scss
@@ -438,6 +438,60 @@ body {
 	}
 }
 
+.navigation.pagination {
+	clear: both;
+	margin: 0 0 1.5em;
+
+	.nav-links {
+		text-align: center;
+
+		.page-numbers {
+			display: inline-block;
+			border: none;
+			border-radius: 3px;
+			line-height: 1;
+			margin: 0 0.25em;
+			padding: 0.5em 0.75em;
+			white-space: nowrap;
+
+			&.dots {
+				background: none;
+			}
+
+			&.current {
+				color: $white;
+				background-color: $color-background-button;
+			}
+		}
+	}
+
+	.paging-nav-text {
+		display: none;
+	}
+
+	@media #{$small-only} {
+
+		.paging-nav-text {
+			display: inline-block;
+			float: left;
+			font-size: 0.9rem;
+			font-weight: normal;
+			color: $white;
+		}
+
+		.nav-links {
+			float: right;
+			padding-right: 0;
+
+			.page-numbers {
+				&:not(.prev, .next) {
+					display: none;
+				}
+			}
+		}
+	}
+}
+
 .comment-navigation .nav-previous,
 .paging-navigation .nav-previous,
 .post-navigation .nav-previous {

--- a/.dev/sass/partials/_menus.scss
+++ b/.dev/sass/partials/_menus.scss
@@ -245,7 +245,7 @@ $submenu-background-color: #121212;
 
 							a {
 
-								&:hover {
+								&:not(.wc-forward):hover {
 									background: none;
 								}
 							}

--- a/.dev/sass/style.scss
+++ b/.dev/sass/style.scss
@@ -40,3 +40,4 @@
 @import "partials/featured-content";
 @import "partials/social";
 @import "partials/jetpack";
+@import "compat/woocommerce";

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  *
  * @var string
  */
-define( 'PRIMER_CHILD_VERSION', '1.0.1' );
+define( 'PRIMER_CHILD_VERSION', '1.1.0' );
 
 /**
  * Move some elements around.

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  *
  * @var string
  */
-define( 'PRIMER_CHILD_VERSION', '1.1.0' );
+define( 'PRIMER_CHILD_VERSION', '1.0.1' );
 
 /**
  * Move some elements around.

--- a/functions.php
+++ b/functions.php
@@ -239,7 +239,8 @@ function escapade_colors( $colors ) {
 		'button_color' => array(
 			'default' => '#55b74e',
 			'css'     => array(
-				'.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart p.buttons a' => array(
+				'.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart p.buttons a,
+				.woocommerce button.button.alt.disabled, .woocommerce button.button.alt.disabled:hover' => array(
 					'background-color' => '%1$s',
 				),
 			),

--- a/functions.php
+++ b/functions.php
@@ -17,10 +17,10 @@ define( 'PRIMER_CHILD_VERSION', '1.0.1' );
  */
 function escapade_move_elements() {
 
-	remove_action( 'primer_header',                 'primer_add_hero', 7 );
-	remove_action( 'primer_after_header',           'primer_add_page_title', 12 );
-	remove_action( 'primer_before_site_navigation', 'primer_add_mobile_menu' );
+	remove_action( 'primer_header',                 'primer_add_hero',              7 );
+	remove_action( 'primer_after_header',           'primer_add_page_title',        12 );
 	remove_action( 'primer_site_info',              'primer_add_social_navigation', 7 );
+	remove_action( 'primer_before_site_navigation', 'primer_add_mobile_menu' );
 
 	if ( ! is_front_page() || ! is_active_sidebar( 'hero' ) ) {
 

--- a/functions.php
+++ b/functions.php
@@ -22,8 +22,6 @@ function escapade_move_elements() {
 	remove_action( 'primer_site_info',              'primer_add_social_navigation', 7 );
 	remove_action( 'primer_before_site_navigation', 'primer_add_mobile_menu' );
 
-	add_filter( 'primer_woocommerce_cart_menu', '__return_false' );
-
 	if ( ! is_front_page() || ! is_active_sidebar( 'hero' ) ) {
 
 		add_action( 'primer_hero', 'primer_add_page_title', 12 );
@@ -233,13 +231,18 @@ function escapade_colors( $colors ) {
 		'link_color' => array(
 			'default'  => '#55b74e',
 			'css'      => array(
-				'.main-navigation ul li:hover, .main-navigation li.current-menu-item, .main-navigation ul li.current-menu-item > a:hover, .main-navigation ul li.current-menu-item > a:visited:hover' => array(
+				'.main-navigation ul li:hover, .main-navigation li.current-menu-item, .main-navigation ul li.current-menu-item > a:hover, .main-navigation ul li.current-menu-item > a:visited:hover, .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart p.buttons a:hover' => array(
 					'background-color' => '%1$s',
 				),
 			),
 		),
 		'button_color' => array(
 			'default' => '#55b74e',
+			'css'     => array(
+				'.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart p.buttons a' => array(
+					'background-color' => '%1$s',
+				),
+			),
 		),
 		'button_text_color' => array(
 			'default'  => '#ffffff',

--- a/functions.php
+++ b/functions.php
@@ -238,12 +238,6 @@ function escapade_colors( $colors ) {
 		),
 		'button_color' => array(
 			'default' => '#55b74e',
-			'css'     => array(
-				'.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart p.buttons a,
-				.woocommerce button.button.alt.disabled, .woocommerce button.button.alt.disabled:hover' => array(
-					'background-color' => '%1$s',
-				),
-			),
 		),
 		'button_text_color' => array(
 			'default'  => '#ffffff',

--- a/functions.php
+++ b/functions.php
@@ -22,6 +22,8 @@ function escapade_move_elements() {
 	remove_action( 'primer_site_info',              'primer_add_social_navigation', 7 );
 	remove_action( 'primer_before_site_navigation', 'primer_add_mobile_menu' );
 
+	add_filter( 'primer_woocommerce_cart_menu', '__return_false' );
+
 	if ( ! is_front_page() || ! is_active_sidebar( 'hero' ) ) {
 
 		add_action( 'primer_hero', 'primer_add_page_title', 12 );

--- a/functions.php
+++ b/functions.php
@@ -17,14 +17,14 @@ define( 'PRIMER_CHILD_VERSION', '1.0.1' );
  */
 function escapade_move_elements() {
 
-	remove_action( 'primer_header',                 'primer_add_hero' );
-	remove_action( 'primer_after_header',           'primer_add_page_title' );
+	remove_action( 'primer_header',                 'primer_add_hero', 7 );
+	remove_action( 'primer_after_header',           'primer_add_page_title', 12 );
 	remove_action( 'primer_before_site_navigation', 'primer_add_mobile_menu' );
 	remove_action( 'primer_site_info',              'primer_add_social_navigation', 7 );
 
 	if ( ! is_front_page() || ! is_active_sidebar( 'hero' ) ) {
 
-		add_action( 'primer_hero', 'primer_add_page_title' );
+		add_action( 'primer_hero', 'primer_add_page_title', 12 );
 
 	}
 

--- a/functions.php
+++ b/functions.php
@@ -264,9 +264,7 @@ function escapade_colors( $colors ) {
 		'menu_background_color' => array(
 			'default' => '#f5f5f5',
 			'css'     => array(
-				'.side-masthead,
-				.main-navigation li.menu-item-has-children:hover > ul.primer-wc-cart-sub-menu,
-				.main-navigation ul.primer-wc-cart-sub-menu li:hover' => array(
+				'.side-masthead' => array(
 					'background-color' => '%1$s',
 				),
 			),

--- a/functions.php
+++ b/functions.php
@@ -264,7 +264,9 @@ function escapade_colors( $colors ) {
 		'menu_background_color' => array(
 			'default' => '#f5f5f5',
 			'css'     => array(
-				'.side-masthead' => array(
+				'.side-masthead,
+				.main-navigation li.menu-item-has-children:hover > ul.primer-wc-cart-sub-menu,
+				.main-navigation ul.primer-wc-cart-sub-menu li:hover' => array(
 					'background-color' => '%1$s',
 				),
 			),

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4267,3 +4267,110 @@ header .social-menu {
 
 #wpstats {
   display: none; }
+
+.main-navigation .menu-item-object-cart:hover a {
+  background: transparent; }
+
+ul.site-header-cart.menu {
+  width: 100%;
+  max-width: 275px;
+  padding: 0;
+  list-style: none;
+  float: left;
+  display: none;
+  position: relative;
+  z-index: 10001; }
+
+.site-footer-inner .woocommerce-cart-menu-item,
+.site-info-wrapper .woocommerce-cart-menu-item {
+  display: none; }
+
+.widget_shopping_cart {
+  float: right;
+  padding: 0 1rem;
+  margin-bottom: .5em; }
+  .widget_shopping_cart .quantity {
+    font-style: italic;
+    color: #fff; }
+  .widget_shopping_cart .total {
+    color: #fff; }
+  .widget_shopping_cart ul.product_list_widget {
+    position: relative !important;
+    right: 0; }
+  .widget_shopping_cart p.buttons,
+  .widget_shopping_cart .total,
+  .widget_shopping_cart .product_list_widget {
+    float: right;
+    width: 100%; }
+  .widget_shopping_cart .total strong {
+    text-index: 0; }
+  .widget_shopping_cart p.buttons {
+    padding: .5em;
+    margin-bottom: 0; }
+
+.woocommerce-cart-menu-item .sub-menu {
+  background: transparent; }
+
+.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  padding-bottom: 5px;
+  border-bottom: none;
+  padding: .5em 1em;
+  text-indent: 0; }
+  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a {
+    border-bottom: none; }
+  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+    padding: .5em 0em;
+    margin: 0;
+    width: 100%;
+    text-indent: 1.75rem; }
+
+.woocommerce-cart-menu-item .product_list_widget {
+  border: none;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  display: inline-block;
+  right: 0 !important;
+  background: inherit; }
+
+.woocommerce-cart-menu-item .widget_shopping_cart {
+  padding: 0; }
+  .woocommerce-cart-menu-item .widget_shopping_cart .total {
+    margin: 0 0 10px 0;
+    padding-top: 10px;
+    text-align: center; }
+  .woocommerce-cart-menu-item .widget_shopping_cart .total strong {
+    text-indent: 0; }
+  .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a {
+    text-align: center;
+    width: 100%;
+    text-indent: 0; }
+    .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a:first-child {
+      margin-bottom: 5px; }
+
+.woocommerce-cart-menu-item .cart-preview-count {
+  margin-right: 8px; }
+
+.woocommerce-cart-menu-item .cart_list li a.remove {
+  position: relative;
+  float: right;
+  padding: 0;
+  margin-top: 18px;
+  text-indent: 0;
+  margin-left: 5px;
+  z-index: 1001;
+  line-height: .8;
+  text-indent: 0 !important; }
+  .woocommerce-cart-menu-item .cart_list li a.remove:hover {
+    background: red !important; }
+
+li#woocommerce-cart-menu-item li.mini_cart_item a {
+  border-bottom: none;
+  text-indent: 15px;
+  margin-right: 10px; }
+
+@media only screen and (min-width: 55.063em) {
+  li#woocommerce-cart-menu-item .sub-menu {
+    margin-right: -6em; } }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4316,13 +4316,14 @@ header .social-menu {
     float: right;
     width: 100%; }
   .primer-wc-cart-menu .widget_shopping_cart .total {
-    margin: 0 0 10px 0;
-    padding-top: 10px;
+    margin: 0;
+    padding: 10px 0;
     text-align: center; }
     .primer-wc-cart-menu .widget_shopping_cart .total strong {
       text-index: 0; }
   .primer-wc-cart-menu .widget_shopping_cart p.buttons {
     padding: .5em;
+    padding-top: 0;
     margin-bottom: 0; }
     .primer-wc-cart-menu .widget_shopping_cart p.buttons a {
       text-align: center;
@@ -4367,19 +4368,15 @@ body.single-product span.onsale {
 body.woocommerce-cart .primer-wc-cart-sub-menu {
   display: none; }
 
-.woocommerce #content table.cart img,
 .woocommerce table.cart img,
-.woocommerce-page #content table.cart img,
 .woocommerce-page table.cart img {
   width: 100%;
   max-width: 100px;
   margin-bottom: 0; }
 
-.woocommerce #content table.cart td.actions .input-text,
 .woocommerce table.cart td.actions .input-text,
-.woocommerce-page #content table.cart td.actions .input-text,
 .woocommerce-page table.cart td.actions .input-text {
-  padding: 7px; }
+  padding: 7px !important; }
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4273,8 +4273,7 @@ header .social-menu {
 
 .primer-wc-cart-menu .widget_shopping_cart {
   float: right;
-  padding: 0;
-  background: #121212; }
+  padding: 0; }
   .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item {
     padding: 0;
     margin: 0;
@@ -4283,23 +4282,21 @@ header .social-menu {
     border-bottom: none;
     padding: .5em 1em;
     text-indent: 0; }
-    .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a {
+    .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a,
+    .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item .quantity,
+    .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a:hover {
       border-bottom: none;
       color: #757575; }
-    .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item:hover a,
-    .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a:hover {
-      color: #fff; }
     .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
       margin: 0;
       width: 100%;
-      padding: .3em 1em .5em 0;
+      padding: .3em 1em 5px 0;
       text-indent: 1px; }
   .primer-wc-cart-menu .widget_shopping_cart .quantity {
     font-style: italic;
-    color: #fff;
     padding-right: 1.3em; }
   .primer-wc-cart-menu .widget_shopping_cart .total {
-    color: #fff; }
+    color: #757575; }
   .primer-wc-cart-menu .widget_shopping_cart ul.product_list_widget {
     position: relative;
     right: 0 !important;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4322,10 +4322,10 @@ ul.site-header-cart.menu {
   .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a {
     border-bottom: none; }
   .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
-    padding: .5em 0em;
     margin: 0;
     width: 100%;
-    text-indent: 1.75rem; }
+    padding: .5em;
+    text-indent: 1px !important; }
 
 .woocommerce-cart-menu-item .product_list_widget {
   border: none;
@@ -4374,3 +4374,13 @@ li#woocommerce-cart-menu-item li.mini_cart_item a {
 @media only screen and (min-width: 55.063em) {
   li#woocommerce-cart-menu-item .sub-menu {
     margin-right: -6em; } }
+
+@media only screen and (max-width: 55em) {
+  li#woocommerce-cart-menu-item .widget_shopping_cart {
+    width: 100%; }
+  li#woocommerce-cart-menu-item .widget_shopping_cart .quantity,
+  li#woocommerce-cart-menu-item .widget_shopping_cart .total {
+    color: inherit; }
+  li#woocommerce-cart-menu-item .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) img {
+    width: 100%;
+    max-width: 65px; } }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4268,9 +4268,6 @@ header .social-menu {
 #wpstats {
   display: none; }
 
-.primer-wc-cart-menu .primer-wc-cart-sub-menu {
-  background: transparent; }
-
 .primer-wc-cart-menu .widget_shopping_cart {
   float: right;
   padding: 0; }
@@ -4341,6 +4338,13 @@ header .social-menu {
 
 .primer-wc-cart-menu .cart-preview-count {
   margin-right: 8px; }
+
+li.menu-item-has-children.primer-wc-cart-menu:hover ul.primer-wc-cart-sub-menu {
+  background: #fefefe;
+  -webkit-box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2); }
+  li.menu-item-has-children.primer-wc-cart-menu:hover ul.primer-wc-cart-sub-menu li:hover {
+    background: #fefefe; }
 
 body.post-type-archive,
 body.single-product {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4373,6 +4373,53 @@ header .social-menu {
 .primer-wc-cart-menu .cart-preview-count {
   margin-right: 8px; }
 
+.woocommerce-page div.product .woocommerce-product-gallery figure.woocommerce-product-gallery__wrapper {
+  margin: 0; }
+
+.woocommerce-page div.product .summary {
+  margin-top: 0; }
+
+.woocommerce-page div.product .commentlist {
+  padding-right: 0; }
+
+.woocommerce-page.woocommerce div.product form.cart {
+  margin: 1em 0; }
+
+.woocommerce-page ul.products li.product.primer-2-column-product {
+  width: 48.05%; }
+
+.woocommerce-page .primer-woocommerce .cart .qty {
+  padding: 0.42em; }
+
+.woocommerce-page table.variations tr:hover td {
+  background-color: transparent; }
+
+.woocommerce-page #reviews #comments ol.commentlist li img.avatar {
+  width: 60px; }
+
+.woocommerce-page #reviews #comments ol.commentlist li .comment-text {
+  margin: 0 80px 0 0; }
+
+.woocommerce-page form.woocommerce-cart-form table.cart td.actions #coupon_code {
+  width: 55%;
+  margin-left: 0; }
+
+.woocommerce-page table.cart td.product-thumbnail,
+.woocommerce-page table.cart td.product-remove {
+  text-align: center; }
+  @media only screen and (min-width: 64.063em) and (max-width: 90em) {
+    .woocommerce-page table.cart td.product-thumbnail .remove,
+    .woocommerce-page table.cart td.product-remove .remove {
+      margin: 0 auto; } }
+
+.woocommerce-page table.cart img {
+  width: 100%;
+  max-width: 75px;
+  margin-bottom: 0; }
+
+.woocommerce-page table.cart td.actions .input-text {
+  padding: 7px !important; }
+
 li.menu-item-has-children.primer-wc-cart-menu:hover ul.primer-wc-cart-sub-menu {
   background: #fefefe;
   -webkit-box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2);
@@ -4413,16 +4460,6 @@ body.single-product span.onsale {
 
 body.woocommerce-cart .primer-wc-cart-sub-menu {
   display: none; }
-
-.woocommerce table.cart img,
-.woocommerce-page table.cart img {
-  width: 100%;
-  max-width: 100px;
-  margin-bottom: 0; }
-
-.woocommerce table.cart td.actions .input-text,
-.woocommerce-page table.cart td.actions .input-text {
-  padding: 7px !important; }
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4391,6 +4391,16 @@ header .social-menu {
 .woocommerce-page .primer-woocommerce .cart .qty {
   padding: 0.42em; }
 
+.woocommerce-page span.onsale,
+.woocommerce-page ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
+
 .woocommerce-page table.variations tr:hover td {
   background-color: transparent; }
 
@@ -4440,18 +4450,6 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
 
 .woocommerce a.added_to_cart {
   text-align: right; }
-
-body.post-type-archive span.onsale,
-body.post-type-archive ul.products li.product .onsale,
-body.single-product span.onsale,
-body.single-product ul.products li.product .onsale {
-  padding: 2px 8px;
-  -webkit-border-radius: 0;
-  border-radius: 0;
-  margin: 0;
-  min-height: auto;
-  min-width: auto;
-  line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3119,6 +3119,40 @@ a {
   padding-top: 0;
   padding-bottom: 0; }
 
+.navigation.pagination {
+  clear: both;
+  margin: 0 0 1.5em; }
+  .navigation.pagination .nav-links {
+    text-align: center; }
+    .navigation.pagination .nav-links .page-numbers {
+      display: inline-block;
+      border: none;
+      -webkit-border-radius: 3px;
+      border-radius: 3px;
+      line-height: 1;
+      margin: 0 0.25em;
+      padding: 0.5em 0.75em;
+      white-space: nowrap; }
+      .navigation.pagination .nav-links .page-numbers.dots {
+        background: none; }
+      .navigation.pagination .nav-links .page-numbers.current {
+        color: #fefefe;
+        background-color: #55b74e; }
+  .navigation.pagination .paging-nav-text {
+    display: none; }
+  @media only screen and (max-width: 55em) {
+    .navigation.pagination .paging-nav-text {
+      display: inline-block;
+      float: right;
+      font-size: 0.9rem;
+      font-weight: normal;
+      color: #fefefe; }
+    .navigation.pagination .nav-links {
+      float: left;
+      padding-left: 0; }
+      .navigation.pagination .nav-links .page-numbers:not(.prev):not(.next) {
+        display: none; } }
+
 .comment-navigation .nav-previous,
 .paging-navigation .nav-previous,
 .post-navigation .nav-previous {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2983,7 +2983,7 @@ a {
             float: none;
             display: block;
             margin: 0; }
-            .main-navigation li.menu-item-has-children:hover > ul li a:hover {
+            .main-navigation li.menu-item-has-children:hover > ul li a:not(.wc-forward):hover {
               background: none; } }
 
 @media only screen and (min-width: 55.063em) {
@@ -4268,110 +4268,81 @@ header .social-menu {
 #wpstats {
   display: none; }
 
-.main-navigation .menu-item-object-cart:hover a {
+.primer-wc-cart-menu .primer-wc-cart-sub-menu {
   background: transparent; }
 
-ul.site-header-cart.menu {
-  width: 100%;
-  max-width: 275px;
-  padding: 0;
-  list-style: none;
-  float: left;
-  display: none;
-  position: relative;
-  z-index: 10001; }
-
-.site-footer-inner .woocommerce-cart-menu-item,
-.site-info-wrapper .woocommerce-cart-menu-item {
-  display: none; }
-
-.widget_shopping_cart {
+.primer-wc-cart-menu .widget_shopping_cart {
   float: right;
-  padding: 0 1rem;
-  margin-bottom: .5em; }
-  .widget_shopping_cart .quantity {
-    font-style: italic;
-    color: #fff; }
-  .widget_shopping_cart .total {
-    color: #fff; }
-  .widget_shopping_cart ul.product_list_widget {
-    position: relative !important;
-    right: 0;
-    max-height: 250px;
-    overflow-y: auto; }
-  .widget_shopping_cart p.buttons,
-  .widget_shopping_cart .total,
-  .widget_shopping_cart .product_list_widget {
-    float: right;
-    width: 100%; }
-  .widget_shopping_cart .total strong {
-    text-index: 0; }
-  .widget_shopping_cart p.buttons {
-    padding: .5em;
-    margin-bottom: 0; }
-
-.woocommerce-cart-menu-item .sub-menu {
-  background: transparent; }
-
-.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
   padding: 0;
-  margin: 0;
-  width: 100%;
-  padding-bottom: 5px;
-  border-bottom: none;
-  padding: .5em 1em;
-  text-indent: 0; }
-  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a {
-    border-bottom: none; }
-  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+  background: #121212; }
+  .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item {
+    padding: 0;
     margin: 0;
     width: 100%;
-    padding: .5em;
-    text-indent: 1px !important; }
-
-.woocommerce-cart-menu-item .product_list_widget {
-  border: none;
-  -webkit-box-shadow: none;
-  box-shadow: none;
-  display: inline-block;
-  right: 0 !important;
-  background: inherit; }
-
-.woocommerce-cart-menu-item .widget_shopping_cart {
-  padding: 0; }
-  .woocommerce-cart-menu-item .widget_shopping_cart .total {
+    padding-bottom: 5px;
+    border-bottom: none;
+    padding: .5em 1em;
+    text-indent: 0; }
+    .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a {
+      border-bottom: none;
+      color: #757575; }
+    .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item:hover a,
+    .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a:hover {
+      color: #fff; }
+    .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+      margin: 0;
+      width: 100%;
+      padding: .3em 1em .5em 0;
+      text-indent: 1px; }
+  .primer-wc-cart-menu .widget_shopping_cart .quantity {
+    font-style: italic;
+    color: #fff;
+    padding-right: 1.3em; }
+  .primer-wc-cart-menu .widget_shopping_cart .total {
+    color: #fff; }
+  .primer-wc-cart-menu .widget_shopping_cart ul.product_list_widget {
+    position: relative;
+    right: 0 !important;
+    max-height: 250px;
+    overflow-y: auto;
+    border: none;
+    -webkit-box-shadow: none;
+    box-shadow: none;
+    display: inline-block;
+    background: inherit; }
+  .primer-wc-cart-menu .widget_shopping_cart p.buttons,
+  .primer-wc-cart-menu .widget_shopping_cart .total,
+  .primer-wc-cart-menu .widget_shopping_cart .product_list_widget {
+    float: right;
+    width: 100%; }
+  .primer-wc-cart-menu .widget_shopping_cart .total {
     margin: 0 0 10px 0;
     padding-top: 10px;
     text-align: center; }
-  .woocommerce-cart-menu-item .widget_shopping_cart .total strong {
-    text-indent: 0; }
-  .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a {
-    text-align: center;
-    width: 100%;
-    text-indent: 0; }
-    .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a:first-child {
-      margin-bottom: 5px; }
+    .primer-wc-cart-menu .widget_shopping_cart .total strong {
+      text-index: 0; }
+  .primer-wc-cart-menu .widget_shopping_cart p.buttons {
+    padding: .5em;
+    margin-bottom: 0; }
+    .primer-wc-cart-menu .widget_shopping_cart p.buttons a {
+      text-align: center;
+      width: 100%;
+      text-indent: 0; }
+      .primer-wc-cart-menu .widget_shopping_cart p.buttons a:first-child {
+        margin-bottom: 5px; }
 
-.woocommerce-cart-menu-item .cart-preview-count {
-  margin-right: 8px; }
-
-.woocommerce-cart-menu-item .cart_list li a.remove {
-  position: relative;
+.primer-wc-cart-menu .cart_list li a.remove {
   float: right;
   padding: 0;
-  margin-top: 18px;
+  margin: 17px 10px 0 5px;
   text-indent: 0;
-  margin-left: 5px;
   z-index: 1001;
-  line-height: .8;
-  text-indent: 0 !important; }
-  .woocommerce-cart-menu-item .cart_list li a.remove:hover {
+  line-height: 1; }
+  .primer-wc-cart-menu .cart_list li a.remove:hover {
     background: red !important; }
 
-li#woocommerce-cart-menu-item li.mini_cart_item a {
-  border-bottom: none;
-  text-indent: 15px;
-  margin-right: 10px; }
+.primer-wc-cart-menu .cart-preview-count {
+  margin-right: 8px; }
 
 body.post-type-archive,
 body.single-product {
@@ -4393,16 +4364,35 @@ body.single-product span.onsale {
   top: 0;
   right: 0; }
 
-@media only screen and (min-width: 55.063em) {
-  li#woocommerce-cart-menu-item .sub-menu {
-    margin-right: -6em; } }
+body.woocommerce-cart .primer-wc-cart-sub-menu {
+  display: none; }
+
+.woocommerce #content table.cart img,
+.woocommerce table.cart img,
+.woocommerce-page #content table.cart img,
+.woocommerce-page table.cart img {
+  width: 100%;
+  max-width: 100px;
+  margin-bottom: 0; }
+
+.woocommerce #content table.cart td.actions .input-text,
+.woocommerce table.cart td.actions .input-text,
+.woocommerce-page #content table.cart td.actions .input-text,
+.woocommerce-page table.cart td.actions .input-text {
+  padding: 7px; }
+
+.woocommerce ul.products li.product a.add_to_cart_button {
+  width: 100%;
+  font-size: 16px;
+  text-align: center; }
 
 @media only screen and (max-width: 55em) {
-  li#woocommerce-cart-menu-item .widget_shopping_cart {
+  .primer-wc-cart-menu-item .widget_shopping_cart {
     width: 100%; }
-  li#woocommerce-cart-menu-item .widget_shopping_cart .quantity,
-  li#woocommerce-cart-menu-item .widget_shopping_cart .total {
-    color: inherit; }
-  li#woocommerce-cart-menu-item .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) img {
-    width: 100%;
-    max-width: 65px; } }
+    .primer-wc-cart-menu-item .widget_shopping_cart .cart_list {
+      color: #fff; }
+      .primer-wc-cart-menu-item .widget_shopping_cart .cart_list a:nth-child(2) img {
+        width: 100%;
+        max-width: 65px; }
+    .primer-wc-cart-menu-item .widget_shopping_cart .mini_cart_item a.remove {
+      margin-top: 20px; } }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4391,6 +4391,9 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
     .woocommerce a.added_to_cart {
       font-size: 0.75rem; } }
 
+.woocommerce a.added_to_cart {
+  text-align: right; }
+
 body.post-type-archive span.onsale,
 body.post-type-archive ul.products li.product .onsale,
 body.single-product span.onsale,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4380,20 +4380,28 @@ li.menu-item-has-children.primer-wc-cart-menu:hover ul.primer-wc-cart-sub-menu {
   li.menu-item-has-children.primer-wc-cart-menu:hover ul.primer-wc-cart-sub-menu li:hover {
     background: #fefefe; }
 
-body.post-type-archive,
-body.single-product {
-  /* On Sale Badge */ }
-  body.post-type-archive span.onsale,
-  body.post-type-archive ul.products li.product .onsale,
-  body.single-product span.onsale,
-  body.single-product ul.products li.product .onsale {
-    padding: 2px 8px;
-    -webkit-border-radius: 0;
-    border-radius: 0;
-    margin: 0;
-    min-height: auto;
-    min-width: auto;
-    line-height: inherit; }
+body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
+.woocommerce a.added_to_cart {
+  max-width: 100%;
+  white-space: normal;
+  text-align: center;
+  display: block; }
+  @media only screen and (min-width: 64.063em) {
+    body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
+    .woocommerce a.added_to_cart {
+      font-size: 0.75rem; } }
+
+body.post-type-archive span.onsale,
+body.post-type-archive ul.products li.product .onsale,
+body.single-product span.onsale,
+body.single-product ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4296,7 +4296,9 @@ ul.site-header-cart.menu {
     color: #fff; }
   .widget_shopping_cart ul.product_list_widget {
     position: relative !important;
-    right: 0; }
+    right: 0;
+    max-height: 250px;
+    overflow-y: auto; }
   .widget_shopping_cart p.buttons,
   .widget_shopping_cart .total,
   .widget_shopping_cart .product_list_widget {
@@ -4370,6 +4372,26 @@ li#woocommerce-cart-menu-item li.mini_cart_item a {
   border-bottom: none;
   text-indent: 15px;
   margin-right: 10px; }
+
+body.post-type-archive,
+body.single-product {
+  /* On Sale Badge */ }
+  body.post-type-archive span.onsale,
+  body.post-type-archive ul.products li.product .onsale,
+  body.single-product span.onsale,
+  body.single-product ul.products li.product .onsale {
+    padding: 2px 8px;
+    -webkit-border-radius: 0;
+    border-radius: 0;
+    margin: 0;
+    min-height: auto;
+    min-width: auto;
+    line-height: inherit; }
+
+body.single-product span.onsale {
+  padding: 3px 18px;
+  top: 0;
+  right: 0; }
 
 @media only screen and (min-width: 55.063em) {
   li#woocommerce-cart-menu-item .sub-menu {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4323,6 +4323,10 @@ header .social-menu {
       width: 100%;
       padding: .3em 1em 5px 0;
       text-indent: 1px; }
+    .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item dl.variation .variation-color {
+      margin-bottom: 0;
+      color: #757575;
+      line-height: 22px; }
   .primer-wc-cart-menu .widget_shopping_cart .quantity {
     font-style: italic;
     padding-right: 1.3em; }

--- a/style.css
+++ b/style.css
@@ -4267,3 +4267,110 @@ header .social-menu {
 
 #wpstats {
   display: none; }
+
+.main-navigation .menu-item-object-cart:hover a {
+  background: transparent; }
+
+ul.site-header-cart.menu {
+  width: 100%;
+  max-width: 275px;
+  padding: 0;
+  list-style: none;
+  float: right;
+  display: none;
+  position: relative;
+  z-index: 10001; }
+
+.site-footer-inner .woocommerce-cart-menu-item,
+.site-info-wrapper .woocommerce-cart-menu-item {
+  display: none; }
+
+.widget_shopping_cart {
+  float: left;
+  padding: 0 1rem;
+  margin-bottom: .5em; }
+  .widget_shopping_cart .quantity {
+    font-style: italic;
+    color: #fff; }
+  .widget_shopping_cart .total {
+    color: #fff; }
+  .widget_shopping_cart ul.product_list_widget {
+    position: relative !important;
+    left: 0; }
+  .widget_shopping_cart p.buttons,
+  .widget_shopping_cart .total,
+  .widget_shopping_cart .product_list_widget {
+    float: left;
+    width: 100%; }
+  .widget_shopping_cart .total strong {
+    text-index: 0; }
+  .widget_shopping_cart p.buttons {
+    padding: .5em;
+    margin-bottom: 0; }
+
+.woocommerce-cart-menu-item .sub-menu {
+  background: transparent; }
+
+.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  padding-bottom: 5px;
+  border-bottom: none;
+  padding: .5em 1em;
+  text-indent: 0; }
+  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a {
+    border-bottom: none; }
+  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+    padding: .5em 0em;
+    margin: 0;
+    width: 100%;
+    text-indent: 1.75rem; }
+
+.woocommerce-cart-menu-item .product_list_widget {
+  border: none;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  display: inline-block;
+  left: 0 !important;
+  background: inherit; }
+
+.woocommerce-cart-menu-item .widget_shopping_cart {
+  padding: 0; }
+  .woocommerce-cart-menu-item .widget_shopping_cart .total {
+    margin: 0 0 10px 0;
+    padding-top: 10px;
+    text-align: center; }
+  .woocommerce-cart-menu-item .widget_shopping_cart .total strong {
+    text-indent: 0; }
+  .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a {
+    text-align: center;
+    width: 100%;
+    text-indent: 0; }
+    .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a:first-child {
+      margin-bottom: 5px; }
+
+.woocommerce-cart-menu-item .cart-preview-count {
+  margin-left: 8px; }
+
+.woocommerce-cart-menu-item .cart_list li a.remove {
+  position: relative;
+  float: left;
+  padding: 0;
+  margin-top: 18px;
+  text-indent: 0;
+  margin-right: 5px;
+  z-index: 1001;
+  line-height: .8;
+  text-indent: 0 !important; }
+  .woocommerce-cart-menu-item .cart_list li a.remove:hover {
+    background: red !important; }
+
+li#woocommerce-cart-menu-item li.mini_cart_item a {
+  border-bottom: none;
+  text-indent: 15px;
+  margin-left: 10px; }
+
+@media only screen and (min-width: 55.063em) {
+  li#woocommerce-cart-menu-item .sub-menu {
+    margin-left: -6em; } }

--- a/style.css
+++ b/style.css
@@ -4316,13 +4316,14 @@ header .social-menu {
     float: left;
     width: 100%; }
   .primer-wc-cart-menu .widget_shopping_cart .total {
-    margin: 0 0 10px 0;
-    padding-top: 10px;
+    margin: 0;
+    padding: 10px 0;
     text-align: center; }
     .primer-wc-cart-menu .widget_shopping_cart .total strong {
       text-index: 0; }
   .primer-wc-cart-menu .widget_shopping_cart p.buttons {
     padding: .5em;
+    padding-top: 0;
     margin-bottom: 0; }
     .primer-wc-cart-menu .widget_shopping_cart p.buttons a {
       text-align: center;
@@ -4367,19 +4368,15 @@ body.single-product span.onsale {
 body.woocommerce-cart .primer-wc-cart-sub-menu {
   display: none; }
 
-.woocommerce #content table.cart img,
 .woocommerce table.cart img,
-.woocommerce-page #content table.cart img,
 .woocommerce-page table.cart img {
   width: 100%;
   max-width: 100px;
   margin-bottom: 0; }
 
-.woocommerce #content table.cart td.actions .input-text,
 .woocommerce table.cart td.actions .input-text,
-.woocommerce-page #content table.cart td.actions .input-text,
 .woocommerce-page table.cart td.actions .input-text {
-  padding: 7px; }
+  padding: 7px !important; }
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;

--- a/style.css
+++ b/style.css
@@ -4268,9 +4268,6 @@ header .social-menu {
 #wpstats {
   display: none; }
 
-.primer-wc-cart-menu .primer-wc-cart-sub-menu {
-  background: transparent; }
-
 .primer-wc-cart-menu .widget_shopping_cart {
   float: left;
   padding: 0; }
@@ -4341,6 +4338,13 @@ header .social-menu {
 
 .primer-wc-cart-menu .cart-preview-count {
   margin-left: 8px; }
+
+li.menu-item-has-children.primer-wc-cart-menu:hover ul.primer-wc-cart-sub-menu {
+  background: #fefefe;
+  -webkit-box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2); }
+  li.menu-item-has-children.primer-wc-cart-menu:hover ul.primer-wc-cart-sub-menu li:hover {
+    background: #fefefe; }
 
 body.post-type-archive,
 body.single-product {

--- a/style.css
+++ b/style.css
@@ -4322,10 +4322,10 @@ ul.site-header-cart.menu {
   .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a {
     border-bottom: none; }
   .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
-    padding: .5em 0em;
     margin: 0;
     width: 100%;
-    text-indent: 1.75rem; }
+    padding: .5em;
+    text-indent: 1px !important; }
 
 .woocommerce-cart-menu-item .product_list_widget {
   border: none;
@@ -4374,3 +4374,13 @@ li#woocommerce-cart-menu-item li.mini_cart_item a {
 @media only screen and (min-width: 55.063em) {
   li#woocommerce-cart-menu-item .sub-menu {
     margin-left: -6em; } }
+
+@media only screen and (max-width: 55em) {
+  li#woocommerce-cart-menu-item .widget_shopping_cart {
+    width: 100%; }
+  li#woocommerce-cart-menu-item .widget_shopping_cart .quantity,
+  li#woocommerce-cart-menu-item .widget_shopping_cart .total {
+    color: inherit; }
+  li#woocommerce-cart-menu-item .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) img {
+    width: 100%;
+    max-width: 65px; } }

--- a/style.css
+++ b/style.css
@@ -2983,7 +2983,7 @@ a {
             float: none;
             display: block;
             margin: 0; }
-            .main-navigation li.menu-item-has-children:hover > ul li a:hover {
+            .main-navigation li.menu-item-has-children:hover > ul li a:not(.wc-forward):hover {
               background: none; } }
 
 @media only screen and (min-width: 55.063em) {
@@ -4268,110 +4268,81 @@ header .social-menu {
 #wpstats {
   display: none; }
 
-.main-navigation .menu-item-object-cart:hover a {
+.primer-wc-cart-menu .primer-wc-cart-sub-menu {
   background: transparent; }
 
-ul.site-header-cart.menu {
-  width: 100%;
-  max-width: 275px;
-  padding: 0;
-  list-style: none;
-  float: right;
-  display: none;
-  position: relative;
-  z-index: 10001; }
-
-.site-footer-inner .woocommerce-cart-menu-item,
-.site-info-wrapper .woocommerce-cart-menu-item {
-  display: none; }
-
-.widget_shopping_cart {
+.primer-wc-cart-menu .widget_shopping_cart {
   float: left;
-  padding: 0 1rem;
-  margin-bottom: .5em; }
-  .widget_shopping_cart .quantity {
-    font-style: italic;
-    color: #fff; }
-  .widget_shopping_cart .total {
-    color: #fff; }
-  .widget_shopping_cart ul.product_list_widget {
-    position: relative !important;
-    left: 0;
-    max-height: 250px;
-    overflow-y: auto; }
-  .widget_shopping_cart p.buttons,
-  .widget_shopping_cart .total,
-  .widget_shopping_cart .product_list_widget {
-    float: left;
-    width: 100%; }
-  .widget_shopping_cart .total strong {
-    text-index: 0; }
-  .widget_shopping_cart p.buttons {
-    padding: .5em;
-    margin-bottom: 0; }
-
-.woocommerce-cart-menu-item .sub-menu {
-  background: transparent; }
-
-.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
   padding: 0;
-  margin: 0;
-  width: 100%;
-  padding-bottom: 5px;
-  border-bottom: none;
-  padding: .5em 1em;
-  text-indent: 0; }
-  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a {
-    border-bottom: none; }
-  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+  background: #121212; }
+  .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item {
+    padding: 0;
     margin: 0;
     width: 100%;
-    padding: .5em;
-    text-indent: 1px !important; }
-
-.woocommerce-cart-menu-item .product_list_widget {
-  border: none;
-  -webkit-box-shadow: none;
-  box-shadow: none;
-  display: inline-block;
-  left: 0 !important;
-  background: inherit; }
-
-.woocommerce-cart-menu-item .widget_shopping_cart {
-  padding: 0; }
-  .woocommerce-cart-menu-item .widget_shopping_cart .total {
+    padding-bottom: 5px;
+    border-bottom: none;
+    padding: .5em 1em;
+    text-indent: 0; }
+    .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a {
+      border-bottom: none;
+      color: #757575; }
+    .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item:hover a,
+    .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a:hover {
+      color: #fff; }
+    .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+      margin: 0;
+      width: 100%;
+      padding: .3em 0 .5em 1em;
+      text-indent: 1px; }
+  .primer-wc-cart-menu .widget_shopping_cart .quantity {
+    font-style: italic;
+    color: #fff;
+    padding-left: 1.3em; }
+  .primer-wc-cart-menu .widget_shopping_cart .total {
+    color: #fff; }
+  .primer-wc-cart-menu .widget_shopping_cart ul.product_list_widget {
+    position: relative;
+    left: 0 !important;
+    max-height: 250px;
+    overflow-y: auto;
+    border: none;
+    -webkit-box-shadow: none;
+    box-shadow: none;
+    display: inline-block;
+    background: inherit; }
+  .primer-wc-cart-menu .widget_shopping_cart p.buttons,
+  .primer-wc-cart-menu .widget_shopping_cart .total,
+  .primer-wc-cart-menu .widget_shopping_cart .product_list_widget {
+    float: left;
+    width: 100%; }
+  .primer-wc-cart-menu .widget_shopping_cart .total {
     margin: 0 0 10px 0;
     padding-top: 10px;
     text-align: center; }
-  .woocommerce-cart-menu-item .widget_shopping_cart .total strong {
-    text-indent: 0; }
-  .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a {
-    text-align: center;
-    width: 100%;
-    text-indent: 0; }
-    .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a:first-child {
-      margin-bottom: 5px; }
+    .primer-wc-cart-menu .widget_shopping_cart .total strong {
+      text-index: 0; }
+  .primer-wc-cart-menu .widget_shopping_cart p.buttons {
+    padding: .5em;
+    margin-bottom: 0; }
+    .primer-wc-cart-menu .widget_shopping_cart p.buttons a {
+      text-align: center;
+      width: 100%;
+      text-indent: 0; }
+      .primer-wc-cart-menu .widget_shopping_cart p.buttons a:first-child {
+        margin-bottom: 5px; }
 
-.woocommerce-cart-menu-item .cart-preview-count {
-  margin-left: 8px; }
-
-.woocommerce-cart-menu-item .cart_list li a.remove {
-  position: relative;
+.primer-wc-cart-menu .cart_list li a.remove {
   float: left;
   padding: 0;
-  margin-top: 18px;
+  margin: 17px 5px 0 10px;
   text-indent: 0;
-  margin-right: 5px;
   z-index: 1001;
-  line-height: .8;
-  text-indent: 0 !important; }
-  .woocommerce-cart-menu-item .cart_list li a.remove:hover {
+  line-height: 1; }
+  .primer-wc-cart-menu .cart_list li a.remove:hover {
     background: red !important; }
 
-li#woocommerce-cart-menu-item li.mini_cart_item a {
-  border-bottom: none;
-  text-indent: 15px;
-  margin-left: 10px; }
+.primer-wc-cart-menu .cart-preview-count {
+  margin-left: 8px; }
 
 body.post-type-archive,
 body.single-product {
@@ -4393,16 +4364,35 @@ body.single-product span.onsale {
   top: 0;
   left: 0; }
 
-@media only screen and (min-width: 55.063em) {
-  li#woocommerce-cart-menu-item .sub-menu {
-    margin-left: -6em; } }
+body.woocommerce-cart .primer-wc-cart-sub-menu {
+  display: none; }
+
+.woocommerce #content table.cart img,
+.woocommerce table.cart img,
+.woocommerce-page #content table.cart img,
+.woocommerce-page table.cart img {
+  width: 100%;
+  max-width: 100px;
+  margin-bottom: 0; }
+
+.woocommerce #content table.cart td.actions .input-text,
+.woocommerce table.cart td.actions .input-text,
+.woocommerce-page #content table.cart td.actions .input-text,
+.woocommerce-page table.cart td.actions .input-text {
+  padding: 7px; }
+
+.woocommerce ul.products li.product a.add_to_cart_button {
+  width: 100%;
+  font-size: 16px;
+  text-align: center; }
 
 @media only screen and (max-width: 55em) {
-  li#woocommerce-cart-menu-item .widget_shopping_cart {
+  .primer-wc-cart-menu-item .widget_shopping_cart {
     width: 100%; }
-  li#woocommerce-cart-menu-item .widget_shopping_cart .quantity,
-  li#woocommerce-cart-menu-item .widget_shopping_cart .total {
-    color: inherit; }
-  li#woocommerce-cart-menu-item .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) img {
-    width: 100%;
-    max-width: 65px; } }
+    .primer-wc-cart-menu-item .widget_shopping_cart .cart_list {
+      color: #fff; }
+      .primer-wc-cart-menu-item .widget_shopping_cart .cart_list a:nth-child(2) img {
+        width: 100%;
+        max-width: 65px; }
+    .primer-wc-cart-menu-item .widget_shopping_cart .mini_cart_item a.remove {
+      margin-top: 20px; } }

--- a/style.css
+++ b/style.css
@@ -3119,6 +3119,40 @@ a {
   padding-top: 0;
   padding-bottom: 0; }
 
+.navigation.pagination {
+  clear: both;
+  margin: 0 0 1.5em; }
+  .navigation.pagination .nav-links {
+    text-align: center; }
+    .navigation.pagination .nav-links .page-numbers {
+      display: inline-block;
+      border: none;
+      -webkit-border-radius: 3px;
+      border-radius: 3px;
+      line-height: 1;
+      margin: 0 0.25em;
+      padding: 0.5em 0.75em;
+      white-space: nowrap; }
+      .navigation.pagination .nav-links .page-numbers.dots {
+        background: none; }
+      .navigation.pagination .nav-links .page-numbers.current {
+        color: #fefefe;
+        background-color: #55b74e; }
+  .navigation.pagination .paging-nav-text {
+    display: none; }
+  @media only screen and (max-width: 55em) {
+    .navigation.pagination .paging-nav-text {
+      display: inline-block;
+      float: left;
+      font-size: 0.9rem;
+      font-weight: normal;
+      color: #fefefe; }
+    .navigation.pagination .nav-links {
+      float: right;
+      padding-right: 0; }
+      .navigation.pagination .nav-links .page-numbers:not(.prev):not(.next) {
+        display: none; } }
+
 .comment-navigation .nav-previous,
 .paging-navigation .nav-previous,
 .post-navigation .nav-previous {

--- a/style.css
+++ b/style.css
@@ -4391,6 +4391,16 @@ header .social-menu {
 .woocommerce-page .primer-woocommerce .cart .qty {
   padding: 0.42em; }
 
+.woocommerce-page span.onsale,
+.woocommerce-page ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
+
 .woocommerce-page table.variations tr:hover td {
   background-color: transparent; }
 
@@ -4440,18 +4450,6 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
 
 .woocommerce a.added_to_cart {
   text-align: left; }
-
-body.post-type-archive span.onsale,
-body.post-type-archive ul.products li.product .onsale,
-body.single-product span.onsale,
-body.single-product ul.products li.product .onsale {
-  padding: 2px 8px;
-  -webkit-border-radius: 0;
-  border-radius: 0;
-  margin: 0;
-  min-height: auto;
-  min-width: auto;
-  line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;

--- a/style.css
+++ b/style.css
@@ -4373,6 +4373,53 @@ header .social-menu {
 .primer-wc-cart-menu .cart-preview-count {
   margin-left: 8px; }
 
+.woocommerce-page div.product .woocommerce-product-gallery figure.woocommerce-product-gallery__wrapper {
+  margin: 0; }
+
+.woocommerce-page div.product .summary {
+  margin-top: 0; }
+
+.woocommerce-page div.product .commentlist {
+  padding-left: 0; }
+
+.woocommerce-page.woocommerce div.product form.cart {
+  margin: 1em 0; }
+
+.woocommerce-page ul.products li.product.primer-2-column-product {
+  width: 48.05%; }
+
+.woocommerce-page .primer-woocommerce .cart .qty {
+  padding: 0.42em; }
+
+.woocommerce-page table.variations tr:hover td {
+  background-color: transparent; }
+
+.woocommerce-page #reviews #comments ol.commentlist li img.avatar {
+  width: 60px; }
+
+.woocommerce-page #reviews #comments ol.commentlist li .comment-text {
+  margin: 0 0 0 80px; }
+
+.woocommerce-page form.woocommerce-cart-form table.cart td.actions #coupon_code {
+  width: 55%;
+  margin-right: 0; }
+
+.woocommerce-page table.cart td.product-thumbnail,
+.woocommerce-page table.cart td.product-remove {
+  text-align: center; }
+  @media only screen and (min-width: 64.063em) and (max-width: 90em) {
+    .woocommerce-page table.cart td.product-thumbnail .remove,
+    .woocommerce-page table.cart td.product-remove .remove {
+      margin: 0 auto; } }
+
+.woocommerce-page table.cart img {
+  width: 100%;
+  max-width: 75px;
+  margin-bottom: 0; }
+
+.woocommerce-page table.cart td.actions .input-text {
+  padding: 7px !important; }
+
 li.menu-item-has-children.primer-wc-cart-menu:hover ul.primer-wc-cart-sub-menu {
   background: #fefefe;
   -webkit-box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2);
@@ -4413,16 +4460,6 @@ body.single-product span.onsale {
 
 body.woocommerce-cart .primer-wc-cart-sub-menu {
   display: none; }
-
-.woocommerce table.cart img,
-.woocommerce-page table.cart img {
-  width: 100%;
-  max-width: 100px;
-  margin-bottom: 0; }
-
-.woocommerce table.cart td.actions .input-text,
-.woocommerce-page table.cart td.actions .input-text {
-  padding: 7px !important; }
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;

--- a/style.css
+++ b/style.css
@@ -4296,7 +4296,9 @@ ul.site-header-cart.menu {
     color: #fff; }
   .widget_shopping_cart ul.product_list_widget {
     position: relative !important;
-    left: 0; }
+    left: 0;
+    max-height: 250px;
+    overflow-y: auto; }
   .widget_shopping_cart p.buttons,
   .widget_shopping_cart .total,
   .widget_shopping_cart .product_list_widget {
@@ -4370,6 +4372,26 @@ li#woocommerce-cart-menu-item li.mini_cart_item a {
   border-bottom: none;
   text-indent: 15px;
   margin-left: 10px; }
+
+body.post-type-archive,
+body.single-product {
+  /* On Sale Badge */ }
+  body.post-type-archive span.onsale,
+  body.post-type-archive ul.products li.product .onsale,
+  body.single-product span.onsale,
+  body.single-product ul.products li.product .onsale {
+    padding: 2px 8px;
+    -webkit-border-radius: 0;
+    border-radius: 0;
+    margin: 0;
+    min-height: auto;
+    min-width: auto;
+    line-height: inherit; }
+
+body.single-product span.onsale {
+  padding: 3px 18px;
+  top: 0;
+  left: 0; }
 
 @media only screen and (min-width: 55.063em) {
   li#woocommerce-cart-menu-item .sub-menu {

--- a/style.css
+++ b/style.css
@@ -4380,20 +4380,28 @@ li.menu-item-has-children.primer-wc-cart-menu:hover ul.primer-wc-cart-sub-menu {
   li.menu-item-has-children.primer-wc-cart-menu:hover ul.primer-wc-cart-sub-menu li:hover {
     background: #fefefe; }
 
-body.post-type-archive,
-body.single-product {
-  /* On Sale Badge */ }
-  body.post-type-archive span.onsale,
-  body.post-type-archive ul.products li.product .onsale,
-  body.single-product span.onsale,
-  body.single-product ul.products li.product .onsale {
-    padding: 2px 8px;
-    -webkit-border-radius: 0;
-    border-radius: 0;
-    margin: 0;
-    min-height: auto;
-    min-width: auto;
-    line-height: inherit; }
+body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
+.woocommerce a.added_to_cart {
+  max-width: 100%;
+  white-space: normal;
+  text-align: center;
+  display: block; }
+  @media only screen and (min-width: 64.063em) {
+    body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
+    .woocommerce a.added_to_cart {
+      font-size: 0.75rem; } }
+
+body.post-type-archive span.onsale,
+body.post-type-archive ul.products li.product .onsale,
+body.single-product span.onsale,
+body.single-product ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;

--- a/style.css
+++ b/style.css
@@ -4323,6 +4323,10 @@ header .social-menu {
       width: 100%;
       padding: .3em 0 5px 1em;
       text-indent: 1px; }
+    .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item dl.variation .variation-color {
+      margin-bottom: 0;
+      color: #757575;
+      line-height: 22px; }
   .primer-wc-cart-menu .widget_shopping_cart .quantity {
     font-style: italic;
     padding-left: 1.3em; }

--- a/style.css
+++ b/style.css
@@ -4273,8 +4273,7 @@ header .social-menu {
 
 .primer-wc-cart-menu .widget_shopping_cart {
   float: left;
-  padding: 0;
-  background: #121212; }
+  padding: 0; }
   .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item {
     padding: 0;
     margin: 0;
@@ -4283,23 +4282,21 @@ header .social-menu {
     border-bottom: none;
     padding: .5em 1em;
     text-indent: 0; }
-    .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a {
+    .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a,
+    .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item .quantity,
+    .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a:hover {
       border-bottom: none;
       color: #757575; }
-    .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item:hover a,
-    .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a:hover {
-      color: #fff; }
     .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
       margin: 0;
       width: 100%;
-      padding: .3em 0 .5em 1em;
+      padding: .3em 0 5px 1em;
       text-indent: 1px; }
   .primer-wc-cart-menu .widget_shopping_cart .quantity {
     font-style: italic;
-    color: #fff;
     padding-left: 1.3em; }
   .primer-wc-cart-menu .widget_shopping_cart .total {
-    color: #fff; }
+    color: #757575; }
   .primer-wc-cart-menu .widget_shopping_cart ul.product_list_widget {
     position: relative;
     left: 0 !important;

--- a/style.css
+++ b/style.css
@@ -4391,6 +4391,9 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
     .woocommerce a.added_to_cart {
       font-size: 0.75rem; } }
 
+.woocommerce a.added_to_cart {
+  text-align: left; }
+
 body.post-type-archive span.onsale,
 body.post-type-archive ul.products li.product .onsale,
 body.single-product span.onsale,


### PR DESCRIPTION
The new version of primer add's priorities to some functions to allow for more precise injection of content or easier management of the content flow.

This patch add's the required priorities to ensure compatibility with the latest version of primer.

**Requires:** https://github.com/godaddy/wp-primer-theme/pull/146

**Update:** Additional tweaks for WooCommerce styles. For a complete list see https://github.com/godaddy/wp-primer-theme/pull/182