### PR TITLE
ISBAT change the 'Site Title Text' customizer control to alter the site title color

### DIFF
--- a/.dev/sass/partials/_menus.scss
+++ b/.dev/sass/partials/_menus.scss
@@ -352,33 +352,6 @@ body {
 		}
 	}
 
-	.site-title {
-		line-height: 53px;
-		font-size: 30px;
-		font-weight: 300;
-		text-transform: uppercase;
-		margin: 5px 0 5px 10px;
-		text-align: left;
-
-		@media #{$medium-up}{
-			margin: 0;
-			text-align: center;
-		}
-
-		a{
-			color: #999;
-
-			&:hover{
-				color: #999;
-				opacity: .8;
-			}
-		}
-
-		.site-description {
-			float: left;
-		}
-	}
-
 	.site-description {
 		display: none;
 	}
@@ -421,6 +394,33 @@ body {
 			display: block;
 			text-align: left;
 		}
+	}
+}
+
+.site-title {
+	line-height: 53px;
+	font-size: 30px;
+	font-weight: 300;
+	text-transform: uppercase;
+	margin: 5px 0 5px 10px;
+	text-align: left;
+
+	@media #{$medium-up}{
+		margin: 0;
+		text-align: center;
+	}
+
+	a{
+		color: #999;
+
+		&:hover{
+			color: #999;
+			opacity: .8;
+		}
+	}
+
+	.site-description {
+		float: left;
 	}
 }
 

--- a/functions.php
+++ b/functions.php
@@ -174,7 +174,8 @@ function escapade_colors( $colors ) {
 
 	unset(
 		$colors['content_background_color'],
-		$colors['footer_widget_content_background_color']
+		$colors['footer_widget_content_background_color'],
+		$colors['tagline_text_color']
 	);
 
 	$overrides = array(

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3058,24 +3058,6 @@ a {
   @media only screen and (max-width: 55em) {
     .side-masthead .site-title-wrapper {
       width: 80%; } }
-  .side-masthead .site-title {
-    line-height: 53px;
-    font-size: 30px;
-    font-weight: 300;
-    text-transform: uppercase;
-    margin: 5px 10px 5px 0;
-    text-align: right; }
-    @media only screen and (min-width: 55.063em) {
-      .side-masthead .site-title {
-        margin: 0;
-        text-align: center; } }
-    .side-masthead .site-title a {
-      color: #999; }
-      .side-masthead .site-title a:hover {
-        color: #999;
-        opacity: .8; }
-    .side-masthead .site-title .site-description {
-      float: right; }
   .side-masthead .site-description {
     display: none; }
   @media only screen and (min-width: 55.063em) {
@@ -3102,6 +3084,25 @@ a {
   .side-masthead .social-menu li {
     display: block;
     text-align: right; }
+
+.site-title {
+  line-height: 53px;
+  font-size: 30px;
+  font-weight: 300;
+  text-transform: uppercase;
+  margin: 5px 10px 5px 0;
+  text-align: right; }
+  @media only screen and (min-width: 55.063em) {
+    .site-title {
+      margin: 0;
+      text-align: center; } }
+  .site-title a {
+    color: #999; }
+    .site-title a:hover {
+      color: #999;
+      opacity: .8; }
+  .site-title .site-description {
+    float: right; }
 
 .navigation .nav-links {
   padding: 1.5em;

--- a/style.css
+++ b/style.css
@@ -3058,24 +3058,6 @@ a {
   @media only screen and (max-width: 55em) {
     .side-masthead .site-title-wrapper {
       width: 80%; } }
-  .side-masthead .site-title {
-    line-height: 53px;
-    font-size: 30px;
-    font-weight: 300;
-    text-transform: uppercase;
-    margin: 5px 0 5px 10px;
-    text-align: left; }
-    @media only screen and (min-width: 55.063em) {
-      .side-masthead .site-title {
-        margin: 0;
-        text-align: center; } }
-    .side-masthead .site-title a {
-      color: #999; }
-      .side-masthead .site-title a:hover {
-        color: #999;
-        opacity: .8; }
-    .side-masthead .site-title .site-description {
-      float: left; }
   .side-masthead .site-description {
     display: none; }
   @media only screen and (min-width: 55.063em) {
@@ -3102,6 +3084,25 @@ a {
   .side-masthead .social-menu li {
     display: block;
     text-align: left; }
+
+.site-title {
+  line-height: 53px;
+  font-size: 30px;
+  font-weight: 300;
+  text-transform: uppercase;
+  margin: 5px 0 5px 10px;
+  text-align: left; }
+  @media only screen and (min-width: 55.063em) {
+    .site-title {
+      margin: 0;
+      text-align: center; } }
+  .site-title a {
+    color: #999; }
+    .site-title a:hover {
+      color: #999;
+      opacity: .8; }
+  .site-title .site-description {
+    float: left; }
 
 .navigation .nav-links {
   padding: 1.5em;


### PR DESCRIPTION
Resolves https://github.com/godaddy/wp-escapade-theme/issues/43

When changing the 'Site Title Text' customizer control nothing happens, as reported in #43.

This patch resolves the issue mentioned above. 

The second change contained in this PR is the site tagline color customizer control has been removed, since escapade doesn't display the site tagline.

![Example](https://cldup.com/-20LntnWdv.png)