### PR TITLE
Display blog pagination links on mobile

### DIFF
--- a/.dev/sass/partials/_menus.scss
+++ b/.dev/sass/partials/_menus.scss
@@ -478,12 +478,6 @@ body {
 		.nav-links {
 			float: right;
 			padding-right: 0;
-
-			.page-numbers {
-				&:not(.prev, .next) {
-					display: none;
-				}
-			}
 		}
 	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3203,9 +3203,7 @@ a {
       color: #fefefe; }
     .navigation.pagination .nav-links {
       float: left;
-      padding-left: 0; }
-      .navigation.pagination .nav-links .page-numbers {
-        display: none; } }
+      padding-left: 0; } }
 
 .comment-navigation .nav-previous,
 .paging-navigation .nav-previous,

--- a/style.css
+++ b/style.css
@@ -3203,9 +3203,7 @@ a {
       color: #fefefe; }
     .navigation.pagination .nav-links {
       float: right;
-      padding-right: 0; }
-      .navigation.pagination .nav-links .page-numbers {
-        display: none; } }
+      padding-right: 0; } }
 
 .comment-navigation .nav-previous,
 .paging-navigation .nav-previous,


### PR DESCRIPTION
Originally reported in https://github.com/godaddy/wp-escapade-theme/issues/86

#### With Patch on Mobile
<img src="https://user-images.githubusercontent.com/5321364/69811976-4a399400-11bd-11ea-89af-fa3508b41e8d.png" width="500" />